### PR TITLE
Disable timeout

### DIFF
--- a/src/Connections/PtOnlineSchemaChangeConnection.php
+++ b/src/Connections/PtOnlineSchemaChangeConnection.php
@@ -41,6 +41,7 @@ class PtOnlineSchemaChangeConnection extends MySqlConnection
     public function runProcess(array $command): int
     {
         $process = new Process($command);
+        $process->setTimeout(null);
         $process->mustRun();
 
         return $process->stop();


### PR DESCRIPTION
By default timeout was set to 60 seconds, some migrations take longer than that so I've disabled it entirely.