### PR TITLE
Remove PHP 7.1 from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 7.1
   - 7.2
   - 7.3
 


### PR DESCRIPTION
## Changelog

- Removed PHP 7.1 as this version is no longer supported