### PR TITLE
Add support for Laravel 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,8 @@
         "php": "^7.0|^8.0",
         "illuminate/database": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0|^7.0|^8.0|^9.0",
         "illuminate/support": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0|^7.0|^8.0|^9.0",
-        "symfony/console": "^3.3|^4.0|^5.0",
-        "symfony/process": "^3.3|^4.0|^5.0"
+        "symfony/console": "^3.3|^4.0|^5.0|^6.0",
+        "symfony/process": "^3.3|^4.0|^5.0|^6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.2|^8.4|^9.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fba7a74b36aa16217545d9eb4fc54e47",
+    "content-hash": "9efb7a6e14d6aa5f735e1eecd670e346",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -755,12 +755,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Ctype\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -999,12 +999,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Mbstring\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1381,12 +1381,12 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\String\\": ""
-                },
                 "files": [
                     "Resources/functions.php"
                 ],
+                "psr-4": {
+                    "Symfony\\Component\\String\\": ""
+                },
                 "exclude-from-classmap": [
                     "/Tests/"
                 ]


### PR DESCRIPTION
Allows Symfony 6.0, which is a dependency of Laravel 9.