### PR TITLE
Hide sensitive data when the command fails

### DIFF
--- a/src/Connections/GhostConnection.php
+++ b/src/Connections/GhostConnection.php
@@ -44,9 +44,9 @@ class GhostConnection extends BaseConnection
     protected function maskSensitiveInformation(array $command): string
     {
         return collect($command)->map(function ($config) {
-            $config = preg_replace('/(password=.*?),/', 'password=*****,', $config);
+            $config = preg_replace('/('.$this->getConfig('password').')/', '*****', $config);
 
-            return preg_replace('/(user=.*?),/', 'user=*****,', $config);
+            return preg_replace('/('.$this->getConfig('username').')/', '*****', $config);
         })->implode(' ');
     }
 }

--- a/src/Connections/PtOnlineSchemaChangeConnection.php
+++ b/src/Connections/PtOnlineSchemaChangeConnection.php
@@ -57,9 +57,9 @@ class PtOnlineSchemaChangeConnection extends BaseConnection
     protected function maskSensitiveInformation(array $command): string
     {
         return collect($command)->map(function ($config) {
-            $config = preg_replace('/(p=.*?),/', 'p=*****,', $config);
+            $config = preg_replace('/('.$this->getConfig('password').'),/', '*****,', $config);
 
-            return preg_replace('/(u=.*?),/', 'u=*****,', $config);
+            return preg_replace('/('.$this->getConfig('username').'),/', '*****,', $config);
         })->implode(' ');
     }
 }

--- a/tests/GhostConnectionTest.php
+++ b/tests/GhostConnectionTest.php
@@ -1,0 +1,47 @@
+<?php
+
+use Daursu\ZeroDowntimeMigration\Connections\GhostConnection;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\Exception\RuntimeException;
+use Symfony\Component\Process\Process;
+
+class GhostConnectionTest extends TestCase
+{
+    public function testItHidesSensitiveInformationWhenCommandFails()
+    {
+        $query = 'alter table `users` ADD `email` varchar(255)';
+        $process = $this->getMockedProcess();
+        $connection = $this->getMockBuilder(GhostConnection::class)
+            ->setConstructorArgs([
+                function () {
+                },
+                'test',
+                '',
+                [
+                    'username' => 'hidden',
+                    'password' => 'hidden',
+                ],
+            ])
+            ->setMethods(['getProcess', 'isPretending'])
+            ->getMock();
+
+        $connection->method('getProcess')->willReturn($process);
+        $process->method('stop')->willReturn(1);
+        $expectedException = new RuntimeException(' The command "\'gh-ost\' \'--max-load=Threads_running=25\' \'--critical-load=Threads_running=1000\' \'--chunk-size=1000\' \'--throttle-control-replicas=myreplica.1.com,myreplica.2.com\' \'--max-lag-millis=1500\' \'--verbose\' \'--switch-to-rbr\' \'--exact-rowcount\' \'--concurrent-rowcount\' \'--default-retries=120\' \'--user=hidden\' \'--password=hidden\' \'--host=127.0.0.1\' \'--port=3306\' \'--database=laravel9\' \'--table=users\' \'--alter=add `city` varchar(255) null\' \'--execute\'" failed.');
+        $process->method('mustRun')->willThrowException($expectedException);
+
+        try {
+            $connection->statement($query);
+        } catch (RuntimeException $e) {
+            $this->assertStringNotContainsString('hidden', $e->getMessage());
+            $this->assertStringContainsString('*****', $e->getMessage());
+        }
+    }
+
+    private function getMockedProcess() {
+        return $this->getMockBuilder(Process::class)
+            ->setConstructorArgs([[]])
+            ->setMethods(['stop', 'mustRun'])
+            ->getMock();
+    }
+}


### PR DESCRIPTION
Fixed a bug that would cause username/pw to be leaked to logs when the command failed.