### PR TITLE
Escape regex when masking sensitive information

### DIFF
--- a/src/Connections/GhostConnection.php
+++ b/src/Connections/GhostConnection.php
@@ -44,9 +44,9 @@ class GhostConnection extends BaseConnection
     protected function maskSensitiveInformation(array $command): string
     {
         return collect($command)->map(function ($config) {
-            $config = preg_replace('/('.$this->getConfig('password').')/', '*****', $config);
+            $config = preg_replace('/('.preg_quote($this->getConfig('password'), '/').')/', '*****', $config);
 
-            return preg_replace('/('.$this->getConfig('username').')/', '*****', $config);
+            return preg_replace('/('.preg_quote($this->getConfig('username'), '/').')/', '*****', $config);
         })->implode(' ');
     }
 }

--- a/src/Connections/PtOnlineSchemaChangeConnection.php
+++ b/src/Connections/PtOnlineSchemaChangeConnection.php
@@ -57,9 +57,9 @@ class PtOnlineSchemaChangeConnection extends BaseConnection
     protected function maskSensitiveInformation(array $command): string
     {
         return collect($command)->map(function ($config) {
-            $config = preg_replace('/('.$this->getConfig('password').'),/', '*****,', $config);
+            $config = preg_replace('/('.preg_quote($this->getConfig('password'), '/').'),/', '*****,', $config);
 
-            return preg_replace('/('.$this->getConfig('username').'),/', '*****,', $config);
+            return preg_replace('/('.preg_quote($this->getConfig('username'), '/').'),/', '*****,', $config);
         })->implode(' ');
     }
 }


### PR DESCRIPTION
In https://github.com/Daursu/laravel-zero-downtime-migration/pull/27, code was added to mask sensitive information anywhere in the output, even on error. However, this takes the username/password and puts it in regex. Our randomly generated DB password contains a `(`, causing the regex to break. By add `preg_quote($password, '/')`, all special regex characters will be escaped `\(` so it doesn't break the regex. I modified the phpunit tests to use a password with all special regex, and it passed on php 8.0.

Thanks!