### PR TITLE
Renamed the options key to params to avoid conflicts with Laravel configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This package support `pt-online-schema-change` and `gh-ost`. Below are the confi
         
         // Additional options, depending on your setup
         // all options available here: https://github.com/github/gh-ost/blob/master/doc/cheatsheet.md
-        'options' => [
+        'params' => [
             '--max-load=Threads_running=25',
             '--critical-load=Threads_running=1000',
             '--chunk-size=1000',
@@ -70,7 +70,7 @@ This package support `pt-online-schema-change` and `gh-ost`. Below are the confi
         
         // Additional options, depending on your setup
         // all options available here: https://www.percona.com/doc/percona-toolkit/LATEST/pt-online-schema-change.html
-        'options' => [
+        'params' => [
             '--nocheck-replication-filters',
             '--nocheck-unique-key-change',
             '--recursion-method=none',
@@ -124,9 +124,9 @@ Run `php artisan:migrate`
 ## Configuration
 All the configuration is done inside `config/database.php` on the connection itself.
 You can pass down custom flags to the raw `pt-online-schema-change` command. 
-Simply add the parameters you want inside the `options` array like so:
+Simply add the parameters you want inside the `params` array like so:
 ```php
-'options' => [
+'params' => [
     '--nocheck-replication-filters',
     '--nocheck-unique-key-change',
     '--recursion-method=none',
@@ -173,7 +173,7 @@ configure how `pt-online-schema-changes` finds your replica slaves.
 Here's an example setup, but feel free to customize it to your own needs
 
 ```php
-'options' => [
+'params' => [
     '--nocheck-replication-filters',
     '--nocheck-unique-key-change',
     '--recursion-method=dsn=D=database_name,t=dsns',
@@ -196,6 +196,31 @@ CREATE TABLE `dsns` (
 INSERT INTO `dsns` (`id`, `parent_id`, `dsn`)
 VALUES
 	(1, NULL, 'h=my-replica-1.example.org,P=3306');
+```
+
+### Upgrade to v1
+There is one breaking change introduced in v1, that requires to modify
+the configuration in `database.php`. The additional parameters array passed down to
+`pt-online-schema-change` or `gh-ost` has been renamed from `options` to `params`.
+This change was required as the name `options` conflicts with Laravel's database configuration
+that is automatically passed down to PDO.
+
+```php
+// Before
+'options' => [
+    '--nocheck-replication-filters',
+    '--nocheck-unique-key-change',
+    '--recursion-method=none',
+    '--chunk-size=2000',
+]
+
+// After
+'params' => [
+    '--nocheck-replication-filters',
+    '--nocheck-unique-key-change',
+    '--recursion-method=none',
+    '--chunk-size=2000',
+]
 ```
 
 ## Gotchas

--- a/src/Connections/BaseConnection.php
+++ b/src/Connections/BaseConnection.php
@@ -125,4 +125,25 @@ abstract class BaseConnection extends MySqlConnection
     {
         return collect($command)->implode(' ');
     }
+
+    /**
+     * Returns additional parameters to be passed down to the command
+     * running the migration against the database.
+     *
+     * @return array
+     */
+    protected function getAdditionalParameters(): array
+    {
+        // Check for breaking changes and display a warning
+        if (collect(Arr::get($this->config, 'options', []))->contains(function ($value) {
+            return str_starts_with($value, '--');
+        }))
+        {
+            $this->output('[Warning] Detected additional parameters passed under "options" array.'
+            .' This has been migrated to "params" array in v1, please check the laravel-zero-downtime-migration'
+            .' upgrade documentation.');
+        }
+
+        return Arr::get($this->config, 'params', []);
+    }
 }

--- a/src/Connections/GhostConnection.php
+++ b/src/Connections/GhostConnection.php
@@ -2,8 +2,6 @@
 
 namespace Daursu\ZeroDowntimeMigration\Connections;
 
-use Illuminate\Support\Arr;
-
 class GhostConnection extends BaseConnection
 {
     /**
@@ -21,7 +19,7 @@ class GhostConnection extends BaseConnection
             [
                 'gh-ost',
             ],
-            Arr::get($this->config, 'options', []),
+            $this->getAdditionalParameters(),
             [
                 sprintf('--user=%s', $this->getConfig('username')),
                 sprintf('--password=%s', $this->getConfig('password')),

--- a/src/Connections/PtOnlineSchemaChangeConnection.php
+++ b/src/Connections/PtOnlineSchemaChangeConnection.php
@@ -2,8 +2,6 @@
 
 namespace Daursu\ZeroDowntimeMigration\Connections;
 
-use Illuminate\Support\Arr;
-
 class PtOnlineSchemaChangeConnection extends BaseConnection
 {
     /**
@@ -22,7 +20,7 @@ class PtOnlineSchemaChangeConnection extends BaseConnection
                 'pt-online-schema-change',
                 $this->isPretending() ? '--dry-run' : '--execute',
             ],
-            Arr::get($this->config, 'options', []),
+            $this->getAdditionalParameters(),
             [
                 '--alter',
                 $this->cleanQuery($query),

--- a/tests/PtOnlineSchemaChangeConnectionTest.php
+++ b/tests/PtOnlineSchemaChangeConnectionTest.php
@@ -87,7 +87,7 @@ class PtOnlineSchemaChangeConnectionTest extends TestCase
     {
         $query = 'alter table `users` ADD `email` varchar(255)';
         $connection = $this->getConnectionWithMockedProcess([
-            'options' => [
+            'params' => [
                 '--nocheck-replication-filters',
                 '--nocheck-unique-key-change',
             ]


### PR DESCRIPTION
This PR fixes a bug where the additional parameters stored in the `app/database.php` under `options` array are passed down to PDO when using Doctrine `doctrine/dbal` package to modify a column in place. This occurs due to the fact that Laravel framework uses the same `options` name for configuring the PDO connection.

With this change, the additional configuration options used by `laravel-zero-downtime-migration` has been renamed to `params`. This is a breaking change that requires everyone using the package to modify their configuration and rename the array to `params`. As such, this will be released under a new major version `1.0.0`. Further upgrade instructions can be found in the README.