### PR TITLE
Add Statement Batching For PtOnlineSchemaChangeConnection

### DIFF
--- a/src/BatchableBlueprint.php
+++ b/src/BatchableBlueprint.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Daursu\ZeroDowntimeMigration;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Connection;
+use Illuminate\Database\Schema\Grammars\Grammar;
+
+/**
+ * A variant of `Blueprint` that allows for connection types to define a `statements`
+ * method to process an array of SQL query strings at once. For example, pt-online-schema-change
+ * lets you pass multiple alter operations to be run on the cloned table.
+ */
+class BatchableBlueprint extends Blueprint
+{
+    public function build(Connection $connection, Grammar $grammar)
+    {
+        if (method_exists($connection, 'statements')) {
+            $statements = $this->toSql($connection, $grammar);
+            return !empty($statements) ? $connection->statements($statements) : null;
+        }
+
+        return parent::build($connection, $grammar);
+    }
+}

--- a/src/Connections/PtOnlineSchemaChangeConnection.php
+++ b/src/Connections/PtOnlineSchemaChangeConnection.php
@@ -22,11 +22,10 @@ class PtOnlineSchemaChangeConnection extends BaseConnection
      *
      * @see \Daursu\ZeroDowntimeMigration\BatchableBlueprint
      *
-     * @param string $query
-     * @param array $bindings
+     * @param string[] $queries
      * @return bool|int
      */
-    public function statements($queries, $bindings = [])
+    public function statements($queries)
     {
         return $this->runQueries($queries);
     }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -6,7 +6,9 @@ use Daursu\ZeroDowntimeMigration\Connections\GhostConnection;
 use Daursu\ZeroDowntimeMigration\Connections\PtOnlineSchemaChangeConnection;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Connectors\MySqlConnector;
+use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\ServiceProvider as IlluminateServiceProvider;
+use ReflectionClass;
 
 class ServiceProvider extends IlluminateServiceProvider
 {
@@ -42,5 +44,17 @@ class ServiceProvider extends IlluminateServiceProvider
         $this->app->bind('db.connector.gh-ost', function () {
             return new MySqlConnector;
         });
+
+        $this->app->bind(Blueprint::class, function ($app, $args = []) {
+            return $this->createInstance(BatchableBlueprint::class, $args);
+        });
+    }
+
+    private function createInstance(string $class, array $args)
+    {
+        return call_user_func_array(
+            [new ReflectionClass($class), 'newInstance'],
+            $args
+        );
     }
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -46,15 +46,7 @@ class ServiceProvider extends IlluminateServiceProvider
         });
 
         $this->app->bind(Blueprint::class, function ($app, $args = []) {
-            return $this->createInstance(BatchableBlueprint::class, $args);
+            return new BatchableBlueprint(...$args);
         });
-    }
-
-    private function createInstance(string $class, array $args)
-    {
-        return call_user_func_array(
-            [new ReflectionClass($class), 'newInstance'],
-            $args
-        );
     }
 }

--- a/tests/Unit/PtOnlineSchemaChangeConnectionTest.php
+++ b/tests/Unit/PtOnlineSchemaChangeConnectionTest.php
@@ -83,6 +83,26 @@ class PtOnlineSchemaChangeConnectionTest extends TestCase
         $connection->statement($query);
     }
 
+    public function testItConcatenatesMultipleStatements()
+    {
+        $queries = [
+            "alter table `users` add `middle_name` varchar(255)",
+            "alter table `users` drop foreign key `created_by_foreign`",
+        ];
+        $connection = $this->getConnectionWithMockedProcess();
+
+        $connection->expects($this->once())
+            ->method('runProcess')
+            ->with($this->callback(function ($command) {
+                $command = implode(' ', $command);
+                return Str::contains($command, '--alter add `middle_name` varchar(255), '.
+                    'drop foreign key `created_by_foreign`');
+            }))
+            ->willReturn(0);
+
+        $connection->statements($queries);
+    }
+
     public function testAdditionalOptionsAreLoadedIn()
     {
         $query = 'alter table `users` ADD `email` varchar(255)';


### PR DESCRIPTION
**Overview**

See #26. This PR makes it so that every individual statement generated as part of `ZeroDowntimeSchema::table` gets passed along to `pt-online-schema-change` in one go, which is both more performant and seemingly in-line with how native `Schema`-based migrations work.

**Thoughts**

1. I plan to battle test this a little more; but, was curious if anyone has any initial concerns with this approach? (which was originally laid out by @dbhynds in the linked issue)
2. If we're concerned about overriding `Blueprint`, perhaps we could make it an opt-in feature by adding in a Laravel version check, a `zero-downtime.php` + `['batched' => true]` config option, and/or a static variable would de-risk the change? The most immediate concern that comes to mind is that this will be incompatible with other libraries overriding `Blueprint`.

**Testing**

I haven't extensively manually tested this change yet; but, as a smoke-test, it works with several of my company's migrations and has been batching groups of `$table->dropForeign` and `$table->foreign` calls correctly.